### PR TITLE
Code climate fix + bug fix in ForgotPW tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,14 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     }
 
     def fileFilter = [
+        // data binding
+        '**/databinding/*',
+        'android/databinding/**/*.class',
+        '**/android/databinding/*Binding.class',
+        '**/android/databinding/*',
+        '**/androidx/databinding/*',
+        '**/BR.*',
+        // android
         '**/R.class',
         '**/R$*.class',
         '**/BuildConfig.*',

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,8 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     sourceDirectories.setFrom(files([mainSrc]))
     classDirectories.setFrom(files([debugTree]))
     executionData.setFrom(fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec', 'outputs/code_coverage/debugAndroidTest/connected/*coverage.ec'
+            'outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec',
+            'outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec'
     ]))
 }
 

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/signIn/ForgotPwActivityTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/signIn/ForgotPwActivityTest.java
@@ -6,10 +6,15 @@ import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static androidx.test.espresso.action.ViewActions.typeText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.intent.Intents.intended;
+import static androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName;
+import static androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent;
 import static androidx.test.espresso.intent.matcher.IntentMatchers.toPackage;
 import static androidx.test.espresso.matcher.ViewMatchers.hasFocus;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import static org.hamcrest.Matchers.allOf;
 
 import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.idling.CountingIdlingResource;
@@ -79,11 +84,28 @@ public class ForgotPwActivityTest {
   public void firesCorrectIntentAfterLinkSent(){
     onView(withId(R.id.emailField)).perform(typeText("anders.hominal@gmail.com"), closeSoftKeyboard());
     onView(withId(R.id.sendReset)).perform(click());
+
+    intended(allOf(
+            toPackage("com.sdp.swiftwallet"),
+            hasComponent(hasClassName(LoginActivity.class.getName()))
+    ));
+  }
+
+  @Test
+  public void sendLinkFailsCorrectly() {
+    onView(withId(R.id.emailField)).perform(typeText("wrong"), closeSoftKeyboard());
+    onView(withId(R.id.sendReset)).perform(click());
+
+    onView(withId(R.id.sendReset)).check(matches(isDisplayed()));
   }
 
   @Test
   public void backButtonFiresIntent(){
     onView(withId(R.id.goBackForgotPW)).perform(click());
-    intended(toPackage("com.sdp.swiftwallet"));
+
+    intended(allOf(
+            toPackage("com.sdp.swiftwallet"),
+            hasComponent(hasClassName(LoginActivity.class.getName()))
+    ));
   }
 }

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/signIn/ForgotPwActivityTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/signIn/ForgotPwActivityTest.java
@@ -11,6 +11,8 @@ import static androidx.test.espresso.matcher.ViewMatchers.hasFocus;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
+import androidx.test.espresso.IdlingRegistry;
+import androidx.test.espresso.idling.CountingIdlingResource;
 import androidx.test.espresso.intent.Intents;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -28,14 +30,29 @@ public class ForgotPwActivityTest {
   @Rule
   public ActivityScenarioRule<ForgotPasswordActivity> testRule = new ActivityScenarioRule<>(ForgotPasswordActivity.class);
 
+  CountingIdlingResource mIdlingResource;
+
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     Intents.init();
   }
 
+  @Before
+  public void registerIdlingResource() {
+    testRule.getScenario().onActivity(activity ->
+            mIdlingResource = activity.getIdlingResource()
+    );
+    IdlingRegistry.getInstance().register(mIdlingResource);
+  }
+
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     Intents.release();
+  }
+
+  @After
+  public void unregisterIdlingResource() {
+    IdlingRegistry.getInstance().unregister(mIdlingResource);
   }
 
   /**

--- a/app/src/main/java/com/sdp/swiftwallet/presentation/signIn/ForgotPasswordActivity.java
+++ b/app/src/main/java/com/sdp/swiftwallet/presentation/signIn/ForgotPasswordActivity.java
@@ -13,6 +13,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.test.espresso.idling.CountingIdlingResource;
+
 import com.google.firebase.auth.FirebaseAuth;
 import com.sdp.cryptowalletapp.R;
 import com.sdp.swiftwallet.common.FirebaseUtil;
@@ -22,15 +24,14 @@ import org.jetbrains.annotations.NotNull;
 
 public class ForgotPasswordActivity extends AppCompatActivity {
 
-
-  private ClientAuth dbClient;
   private FirebaseAuth mAuth;
-  private final String COUNTRY = "en";
-  private final String COUNTRY_CODE = "en_gb";
-
+  private static final String COUNTRY = "en";
+  private static final String COUNTRY_CODE = "en_gb";
 
   private EditText emailView;
   private static final String RESET_PASSWORD_TAG = "RESET_PASSWORD_TAG";
+
+  private CountingIdlingResource mIdlingResource;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -41,29 +42,23 @@ public class ForgotPasswordActivity extends AppCompatActivity {
 
     //Sets up the db
     mAuth = FirebaseUtil.getAuth();
-    setLanguage(COUNTRY, COUNTRY_CODE);
+
+    // Init idling resource for testing purpose
+    mIdlingResource = new CountingIdlingResource("ForgotPW Calls");
 
     emailView = findViewById(R.id.emailField);
 
     //Sets up the button for confirming
     Button sendLink = findViewById(R.id.sendReset);
-    sendLink.setOnClickListener(new OnClickListener() {
-      public void onClick(View v) {
-        checkAndSend(emailView.getText().toString().trim());
-      }
-    });
+    sendLink.setOnClickListener(v -> checkAndSend(emailView.getText().toString().trim()));
 
     Button goBack = findViewById(R.id.goBackForgotPW);
-    goBack.setOnClickListener(new OnClickListener() {
-      public void onClick(View v) {
-        ForgotPasswordActivity.this.startActivity(new Intent(ForgotPasswordActivity.this, LoginActivity.class));
-      }
-    });
+    goBack.setOnClickListener(v -> startActivity(new Intent(ForgotPasswordActivity.this, LoginActivity.class)));
 
     //Hardcoded, to be changed
-    setLanguage(COUNTRY, COUNTRY_CODE);
+    mAuth.setLanguageCode(COUNTRY);
+    mAuth.setLanguageCode(COUNTRY_CODE);
   }
-
 
   /**
    * Checks and sends the email the reset link if the user exists+correctly formatted
@@ -71,9 +66,9 @@ public class ForgotPasswordActivity extends AppCompatActivity {
    * @param email email to send
    */
   public void checkAndSend(@NotNull String email){
-
     if (checkEmail(email, emailView)) {
-      sendPasswordResetEmail(email, this);
+      mIdlingResource.increment();
+      sendPasswordResetEmail(email);
     }
   }
 
@@ -81,29 +76,29 @@ public class ForgotPasswordActivity extends AppCompatActivity {
    * Sends a password reset email to the user
    * @param email email that must previously have been checked
    */
-  public void sendPasswordResetEmail(String email, Activity from){
+  public void sendPasswordResetEmail(String email){
     Log.d(RESET_PASSWORD_TAG, "Trying to send a confirmation email");
     mAuth.sendPasswordResetEmail(email)
         .addOnSuccessListener( a -> {
           Log.d(RESET_PASSWORD_TAG, "Password successfully sent on \n"+email);
-          Toast.makeText(from, "Password successfully sent on \n"+email, Toast.LENGTH_SHORT).show();
+          Toast.makeText(this, "Password successfully sent on \n"+email, Toast.LENGTH_SHORT).show();
           //Start again login activity if successful
-          Intent nextIntent = new Intent(from, LoginActivity.class);
-          from.startActivity(nextIntent);
+          Intent nextIntent = new Intent(this, LoginActivity.class);
+          mIdlingResource.decrement();
+          startActivity(nextIntent);
         }).addOnFailureListener( a -> {
       Log.d(RESET_PASSWORD_TAG, "Something went wrong, please enter a valid email \n"+email);
-      Toast.makeText(from, "Reset error, please correct your email! \n"+email, Toast.LENGTH_SHORT).show();
+      Toast.makeText(this, "Reset error, please correct your email! \n"+email, Toast.LENGTH_SHORT).show();
+      mIdlingResource.decrement();
     });
   }
 
   /**
-   * Sets up language for authentication
-   * @param country country (format "fr=France", ...)
-   * @param countryLanguage country language (format "en_gb"= UK british)
+   * Getter for idling resource, used for testing
+   * @return idling resource used in this activity
    */
-  public void setLanguage(String country, String countryLanguage){
-    mAuth.setLanguageCode(COUNTRY);
-    mAuth.setLanguageCode(COUNTRY_CODE);
+  public CountingIdlingResource getIdlingResource() {
+    return mIdlingResource;
   }
 
 }

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -34,7 +34,6 @@
     android:layout_width="378dp"
     android:layout_height="44dp"
     android:layout_marginTop="8dp"
-    android:ems="10"
     android:inputType="textEmailAddress"
     app:layout_constraintHorizontal_bias="0.421"
     app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION
- Tests in forgotPW shouldn't fail randomly on pipeline.

Note for coverage: a correct workflow when testing would be to run unitTests and androidTests on local by running:
`./gradlew check connectedCheck`
This will run all unitTests in tests package and all interactive tests in androidTests package. Once it is done it is possible to get the coverage under Project view in `app/build/reports/jacoco/jacocoTestReport/html/index.html`. This coverage should be the exact same as the one recorded on codeclimate.