### PR TITLE
Bugfix/transaction history red cards

### DIFF
--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducer.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducer.java
@@ -1,0 +1,40 @@
+package com.sdp.swiftwallet.presentation.transactions;
+
+import com.sdp.swiftwallet.domain.model.transaction.Transaction;
+import com.sdp.swiftwallet.domain.repository.transaction.TransactionHistoryProducer;
+import com.sdp.swiftwallet.domain.repository.transaction.TransactionHistorySubscriber;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DummyProducer implements TransactionHistoryProducer {
+
+    public static DummyProducer INSTANCE = new DummyProducer();
+
+    private final List<TransactionHistorySubscriber> subscribers = new ArrayList<>();
+    private final List<Transaction> transactions = new ArrayList<>();
+
+    @Override
+    public boolean subscribe(TransactionHistorySubscriber subscriber) {
+        subscriber.receiveTransactions(transactions);
+        return subscribers.add(subscriber);
+    }
+
+    @Override
+    public boolean unsubscribe(TransactionHistorySubscriber subscriber) {
+        if (subscribers.contains(subscriber)) {
+            return subscribers.remove(subscriber);
+        }
+        return true;
+    }
+
+    public void alertAll() {
+        for (TransactionHistorySubscriber subscriber : subscribers) {
+            subscriber.receiveTransactions(transactions);
+        }
+    }
+
+    public void addTransaction(Transaction t) {
+        transactions.add(t);
+    }
+}

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducer.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducer.java
@@ -37,4 +37,9 @@ public class DummyProducer implements TransactionHistoryProducer {
     public void addTransaction(Transaction t) {
         transactions.add(t);
     }
+
+    public void clearList() {
+        transactions.clear();
+        alertAll();
+    }
 }

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducerModule.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/DummyProducerModule.java
@@ -1,0 +1,22 @@
+package com.sdp.swiftwallet.presentation.transactions;
+
+import com.sdp.swiftwallet.di.transaction.TransactionHistoryProducerModule;
+import com.sdp.swiftwallet.domain.repository.transaction.TransactionHistoryProducer;
+
+import dagger.Module;
+import dagger.Provides;
+import dagger.hilt.components.SingletonComponent;
+import dagger.hilt.testing.TestInstallIn;
+
+@Module
+@TestInstallIn(
+        components = SingletonComponent.class,
+        replaces = TransactionHistoryProducerModule.class
+)
+public class DummyProducerModule {
+
+    @Provides
+    public static TransactionHistoryProducer provideProducer() {
+        return DummyProducer.INSTANCE;
+    }
+}

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionActivityTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionActivityTest.java
@@ -33,20 +33,9 @@ import dagger.hilt.android.testing.HiltAndroidTest;
 import dagger.hilt.android.testing.UninstallModules;
 import dagger.hilt.components.SingletonComponent;
 
-@UninstallModules(TransactionHistoryProducerModule.class)
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
 public class TransactionActivityTest {
-
-    @Module
-    @InstallIn(SingletonComponent.class)
-    public static class TestModule {
-
-        @Provides
-        public static TransactionHistoryProducer provideProducer() {
-            return producer;
-        }
-    }
 
     private final static Currency CURR_1 = new Currency("DumbCoin", "DUM", 5);
     private final static Currency CURR_2 = new Currency("BitCoin", "BTC", 3);
@@ -56,14 +45,14 @@ public class TransactionActivityTest {
     private final static String THEIR_WALL = "THEIR_WALL";
     private final static List<Currency> currencyList = new ArrayList<>();
 
+    private DummyProducer producer;
+
     static {
         currencyList.add(CURR_1);
         currencyList.add(CURR_2);
         currencyList.add(CURR_3);
         currencyList.add(CURR_4);
     }
-
-    private static DummyHistoryProducer producer = new DummyHistoryProducer();
 
     public ActivityScenarioRule<TransactionActivity> testRule = new ActivityScenarioRule<>(TransactionActivity.class);
     public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
@@ -75,7 +64,7 @@ public class TransactionActivityTest {
     @Before
     public void setup() {
         hiltRule.inject();
-        producer = new DummyHistoryProducer();
+        producer = DummyProducer.INSTANCE;
     }
 
     @Test
@@ -160,34 +149,5 @@ public class TransactionActivityTest {
         producer.addTransaction(t4);
         producer.addTransaction(t5);
         producer.alertAll();
-    }
-
-    public static class DummyHistoryProducer implements TransactionHistoryProducer {
-        private final List<TransactionHistorySubscriber> subscribers = new ArrayList<>();
-        private final List<Transaction> transactions = new ArrayList<>();
-
-        @Override
-        public boolean subscribe(TransactionHistorySubscriber subscriber) {
-            subscriber.receiveTransactions(transactions);
-            return subscribers.add(subscriber);
-        }
-
-        @Override
-        public boolean unsubscribe(TransactionHistorySubscriber subscriber) {
-            if (subscribers.contains(subscriber)) {
-                return subscribers.remove(subscriber);
-            }
-            return true;
-        }
-
-        public void alertAll() {
-            for (TransactionHistorySubscriber subscriber : subscribers) {
-                subscriber.receiveTransactions(transactions);
-            }
-        }
-
-        public void addTransaction(Transaction t) {
-            transactions.add(t);
-        }
     }
 }

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
@@ -50,6 +50,8 @@ public class TransactionHistoryTest {
     private final static String THEIR_WALL = "THEIR_WALL";
 
     private final static List<Currency> currencyList = new ArrayList<>();
+    public static final String GREEN_COLOR = "#4CAF50";
+    public static final String RED_COLOR = "#F44336";
 
     static {
         currencyList.add(CURR_1);
@@ -122,7 +124,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
     }
 
     @Test
@@ -135,7 +137,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
     }
 
     @Test
@@ -148,7 +150,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
     }
 
     @Test
@@ -161,7 +163,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
     }
 
     @Test
@@ -175,7 +177,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
     }
 
     @Test
@@ -188,7 +190,63 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void positiveTransactionAfterLargeListOfNegativeTransactionsIsGreen() throws InterruptedException {
+        int nbTransactions = 100;
+
+        for (int i = 0; i < nbTransactions; i++) {
+            Transaction t = new Transaction(-10, CURR_1, MY_WALL, THEIR_WALL, i);
+            producer.addTransaction(t);
+        }
+
+        producer.addTransaction(
+                new Transaction(10, CURR_1, MY_WALL, THEIR_WALL, nbTransactions)
+        );
+
+        producer.alertAll();
+
+        for (int i = 0; i < nbTransactions; i += nbTransactions/10) {
+            onView(withId(R.id.transaction_recyclerView))
+                    .perform(RecyclerViewActions.scrollToPosition(i));
+        }
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.scrollToPosition(nbTransactions));
+
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void positiveTransactionBeforeLargeListOfNegativeTransactionsDoesntChangeColor() {
+        int nbTransactions = 100;
+
+        producer.addTransaction(
+                new Transaction(10, CURR_1, MY_WALL, THEIR_WALL, nbTransactions)
+        );
+
+        for (int i = 0; i < nbTransactions; i++) {
+            Transaction t = new Transaction(-10, CURR_1, MY_WALL, THEIR_WALL, i);
+            producer.addTransaction(t);
+        }
+
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.scrollToPosition(0));
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+
+        for (int i = 0; i < nbTransactions; i += nbTransactions/10) {
+            onView(withId(R.id.transaction_recyclerView))
+                    .perform(RecyclerViewActions.scrollToPosition(i));
+        }
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.scrollToPosition(0));
+
+        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
     }
 
     public static Matcher<View> withBgColor(final int color) {

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
@@ -50,8 +50,8 @@ public class TransactionHistoryTest {
     private final static String THEIR_WALL = "THEIR_WALL";
 
     private final static List<Currency> currencyList = new ArrayList<>();
-    public static final String GREEN_COLOR = "#4CAF50";
-    public static final String RED_COLOR = "#F44336";
+    public static final int GREEN_COLOR = Color.parseColor("#4CAF50");
+    public static final int RED_COLOR = Color.parseColor("#F44336");
 
     static {
         currencyList.add(CURR_1);
@@ -124,7 +124,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -137,7 +137,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -150,7 +150,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(RED_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -177,7 +177,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
 
-        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(RED_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -190,7 +190,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
-        onView(withBgColor(Color.parseColor(RED_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(RED_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -216,7 +216,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.scrollToPosition(nbTransactions));
 
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
     }
 
     @Test
@@ -236,7 +236,7 @@ public class TransactionHistoryTest {
 
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.scrollToPosition(0));
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
 
         for (int i = 0; i < nbTransactions; i += nbTransactions/10) {
             onView(withId(R.id.transaction_recyclerView))
@@ -246,7 +246,7 @@ public class TransactionHistoryTest {
         onView(withId(R.id.transaction_recyclerView))
                 .perform(RecyclerViewActions.scrollToPosition(0));
 
-        onView(withBgColor(Color.parseColor(GREEN_COLOR))).check(matches(isDisplayed()));
+        onView(withBgColor(GREEN_COLOR)).check(matches(isDisplayed()));
     }
 
     public static Matcher<View> withBgColor(final int color) {

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
@@ -1,0 +1,73 @@
+package com.sdp.swiftwallet.presentation.transactions;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import com.sdp.cryptowalletapp.R;
+import com.sdp.swiftwallet.domain.model.currency.Currency;
+import com.sdp.swiftwallet.domain.model.transaction.Transaction;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+
+import dagger.hilt.android.testing.HiltAndroidRule;
+import dagger.hilt.android.testing.HiltAndroidTest;
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4.class)
+public class TransactionHistoryTest {
+
+    private final static Currency CURR_1 = new Currency("DumbCoin", "DUM", 5);
+    private final static Currency CURR_2 = new Currency("BitCoin", "BTC", 3);
+    private final static Currency CURR_3 = new Currency("Ethereum", "ETH", 4);
+    private final static Currency CURR_4 = new Currency("SwiftCoin", "SWT", 6);
+    private final static String MY_WALL = "MY_WALL";
+    private final static String THEIR_WALL = "THEIR_WALL";
+
+    private static DummyProducer producer = DummyProducer.INSTANCE;
+
+    public ActivityScenarioRule<TransactionActivity> testRule = new ActivityScenarioRule<>(TransactionActivity.class);
+    public HiltAndroidRule hiltRule = new HiltAndroidRule(this);
+
+    @Rule
+    public final RuleChain rule =
+            RuleChain.outerRule(hiltRule).around(testRule);
+
+    @Before
+    public void setup() {
+        hiltRule.inject();
+        producer.clearList();
+        onView(withId(R.id.transaction_historyButton)).perform(click());
+    }
+
+    @Test
+    public void recyclerViewIsDisplayedInHistoryFragment() {
+        onView(withId(R.id.transaction_historyButton)).perform(click());
+        onView(withId(R.id.transaction_historyFragment)).check(matches(isDisplayed()));
+        onView(withId(R.id.transaction_recyclerView)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void addingANewTransactionDisplaysItInHistory() {
+        Transaction t1 = new Transaction(2.2, CURR_2, MY_WALL, THEIR_WALL, 1);
+        Transaction t2 = new Transaction(17.5, CURR_1, MY_WALL, THEIR_WALL, 2);
+        Transaction t3 = new Transaction(-19, CURR_3, MY_WALL, THEIR_WALL, 3);
+        Transaction t4 = new Transaction(22, CURR_4, MY_WALL, THEIR_WALL, 4);
+        Transaction t5 = new Transaction(76, CURR_2, MY_WALL, THEIR_WALL, 5);
+        producer.addTransaction(t1);
+        producer.addTransaction(t2);
+        producer.addTransaction(t3);
+        producer.addTransaction(t4);
+        producer.addTransaction(t5);
+        producer.alertAll();
+    }
+}

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionHistoryTest.java
@@ -5,7 +5,16 @@ import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import android.graphics.Color;
+import android.view.View;
+import android.widget.EditText;
+
+import androidx.cardview.widget.CardView;
+import androidx.test.espresso.contrib.RecyclerViewActions;
+import androidx.test.espresso.intent.Checks;
+import androidx.test.espresso.matcher.BoundedMatcher;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -13,11 +22,18 @@ import com.sdp.cryptowalletapp.R;
 import com.sdp.swiftwallet.domain.model.currency.Currency;
 import com.sdp.swiftwallet.domain.model.transaction.Transaction;
 
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
 
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
@@ -32,6 +48,16 @@ public class TransactionHistoryTest {
     private final static Currency CURR_4 = new Currency("SwiftCoin", "SWT", 6);
     private final static String MY_WALL = "MY_WALL";
     private final static String THEIR_WALL = "THEIR_WALL";
+
+    private final static List<Currency> currencyList = new ArrayList<>();
+
+    static {
+        currencyList.add(CURR_1);
+        currencyList.add(CURR_2);
+        currencyList.add(CURR_3);
+    }
+
+    private final static double AMOUNT_BOUND = 100;
 
     private static DummyProducer producer = DummyProducer.INSTANCE;
 
@@ -58,16 +84,126 @@ public class TransactionHistoryTest {
 
     @Test
     public void addingANewTransactionDisplaysItInHistory() {
-        Transaction t1 = new Transaction(2.2, CURR_2, MY_WALL, THEIR_WALL, 1);
-        Transaction t2 = new Transaction(17.5, CURR_1, MY_WALL, THEIR_WALL, 2);
-        Transaction t3 = new Transaction(-19, CURR_3, MY_WALL, THEIR_WALL, 3);
-        Transaction t4 = new Transaction(22, CURR_4, MY_WALL, THEIR_WALL, 4);
-        Transaction t5 = new Transaction(76, CURR_2, MY_WALL, THEIR_WALL, 5);
-        producer.addTransaction(t1);
-        producer.addTransaction(t2);
-        producer.addTransaction(t3);
-        producer.addTransaction(t4);
-        producer.addTransaction(t5);
+        Random r = new Random();
+
+        double amount = r.nextDouble() * AMOUNT_BOUND;
+        amount -= r.nextDouble() * AMOUNT_BOUND;
+        Currency curr = currencyList.get(r.nextInt(currencyList.size()));
+        int id = r.nextInt(Integer.MAX_VALUE);
+
+        Transaction t = new Transaction(amount, curr, MY_WALL, THEIR_WALL, id);
+
+        producer.addTransaction(t);
         producer.alertAll();
+
+        String idString = "Transaction ID #" + id;
+        String amountString = String.format(
+                Locale.US,
+                "%.1f %s",
+                t.getAmount(), t.getSymbol()
+        );
+        String descriptionString = t.toString();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+
+        onView(withText(idString)).check(matches(isDisplayed()));
+        onView(withText(amountString)).check(matches(isDisplayed()));
+        onView(withText(descriptionString)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void positiveTransactionIsGreen() {
+        Transaction t = new Transaction(10, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+
+        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void smallestPositiveIsGreen() {
+        double amount = Double.MIN_VALUE;
+        Transaction t = new Transaction(amount, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void largestPositiveIsGreen() {
+        double amount = AMOUNT_BOUND;
+        Transaction t = new Transaction(amount, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+        onView(withBgColor(Color.parseColor("#4CAF50"))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void negativeTransactionIsRed() {
+        Transaction t = new Transaction(-10, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+
+        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void smallestNegativeIsRed() {
+        double amount = -Double.MIN_VALUE;
+        Transaction t = new Transaction(amount, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+
+        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void largestNegativeIsRed() {
+        double amount = -AMOUNT_BOUND;
+        Transaction t = new Transaction(amount, CURR_1, MY_WALL, THEIR_WALL, 0);
+
+        producer.addTransaction(t);
+        producer.alertAll();
+
+        onView(withId(R.id.transaction_recyclerView))
+                .perform(RecyclerViewActions.actionOnItemAtPosition(0, click()));
+        onView(withBgColor(Color.parseColor("#F44336"))).check(matches(isDisplayed()));
+    }
+
+    public static Matcher<View> withBgColor(final int color) {
+        Checks.checkNotNull(color);
+        return new BoundedMatcher<View, CardView>(CardView.class) {
+
+            @Override
+            protected boolean matchesSafely(CardView item) {
+                return color == (item.getCardBackgroundColor().getDefaultColor());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with text color: ");
+            }
+        };
     }
 }

--- a/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionStatsTest.java
+++ b/app/src/androidTest/java/com/sdp/swiftwallet/presentation/transactions/TransactionStatsTest.java
@@ -10,11 +10,8 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.sdp.cryptowalletapp.R;
-import com.sdp.swiftwallet.di.transaction.TransactionHistoryProducerModule;
 import com.sdp.swiftwallet.domain.model.currency.Currency;
 import com.sdp.swiftwallet.domain.model.transaction.Transaction;
-import com.sdp.swiftwallet.domain.repository.transaction.TransactionHistoryProducer;
-import com.sdp.swiftwallet.domain.repository.transaction.TransactionHistorySubscriber;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,17 +22,19 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 
-import dagger.Module;
-import dagger.Provides;
-import dagger.hilt.InstallIn;
 import dagger.hilt.android.testing.HiltAndroidRule;
 import dagger.hilt.android.testing.HiltAndroidTest;
-import dagger.hilt.android.testing.UninstallModules;
-import dagger.hilt.components.SingletonComponent;
 
 @HiltAndroidTest
 @RunWith(AndroidJUnit4.class)
-public class TransactionActivityTest {
+public class TransactionStatsTest {
+
+    private final static Currency CURR_1 = new Currency("DumbCoin", "DUM", 5);
+    private final static Currency CURR_2 = new Currency("BitCoin", "BTC", 3);
+    private final static Currency CURR_3 = new Currency("Ethereum", "ETH", 4);
+    private final static Currency CURR_4 = new Currency("SwiftCoin", "SWT", 6);
+    private final static String MY_WALL = "MY_WALL";
+    private final static String THEIR_WALL = "THEIR_WALL";
 
     private static DummyProducer producer = DummyProducer.INSTANCE;
 
@@ -50,44 +49,29 @@ public class TransactionActivityTest {
     public void setup() {
         hiltRule.inject();
         producer.clearList();
+        onView(withId(R.id.transaction_statsButton)).perform(click());
     }
 
     @Test
-    public void historyButtonIsDisplayed() {
-        onView(withId(R.id.transaction_historyButton)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void statsButtonIsDisplayed() {
-        onView(withId(R.id.transaction_statsButton)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void fragmentLayoutIsDisplayed() {
-        onView(withId(R.id.transaction_flFragment)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void activityStartsWithHistoryFragmentDisplayed() {
-        onView(withId(R.id.transaction_historyFragment)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void historyButtonDisplaysHistoryFragment() {
-        onView(withId(R.id.transaction_historyButton)).perform(click());
-        onView(withId(R.id.transaction_historyFragment)).check(matches(isDisplayed()));
-    }
-
-    @Test
-    public void statsButtonDisplaysStatsFragment() {
+    public void pieChartIsDisplayedInStatsFragment() {
         onView(withId(R.id.transaction_statsButton)).perform(click());
         onView(withId(R.id.transaction_statsFragment)).check(matches(isDisplayed()));
+        onView(withId(R.id.transaction_pieChart)).check(matches(isDisplayed()));
     }
 
     @Test
-    public void canSwitchBackToHistoryFragmentAfterGoingToStats() {
+    public void addingANewTransactionDisplaysItInStats() {
         onView(withId(R.id.transaction_statsButton)).perform(click());
-        onView(withId(R.id.transaction_historyButton)).perform(click());
-        onView(withId(R.id.transaction_historyFragment)).check(matches(isDisplayed()));
+        Transaction t1 = new Transaction(2.2, CURR_2, MY_WALL, THEIR_WALL, 1);
+        Transaction t2 = new Transaction(17.5, CURR_1, MY_WALL, THEIR_WALL, 2);
+        Transaction t3 = new Transaction(-19, CURR_3, MY_WALL, THEIR_WALL, 3);
+        Transaction t4 = new Transaction(22, CURR_4, MY_WALL, THEIR_WALL, 4);
+        Transaction t5 = new Transaction(76, CURR_2, MY_WALL, THEIR_WALL, 5);
+        producer.addTransaction(t1);
+        producer.addTransaction(t2);
+        producer.addTransaction(t3);
+        producer.addTransaction(t4);
+        producer.addTransaction(t5);
+        producer.alertAll();
     }
 }

--- a/app/src/main/java/com/sdp/swiftwallet/domain/model/transaction/TransactionAdapter.java
+++ b/app/src/main/java/com/sdp/swiftwallet/domain/model/transaction/TransactionAdapter.java
@@ -26,6 +26,9 @@ public class TransactionAdapter extends RecyclerView.Adapter<TransactionAdapter.
     private final List<Transaction> transactionHistory;
     private final Context context;
 
+    private final static int RED_COLOR = Color.parseColor("#FFF44336");
+    private final static int GREEN_COLOR = Color.parseColor("#FF4CAF50");
+
     public TransactionAdapter(Context context, List<Transaction> transactionHistory) {
         this.context = context;
         this.transactionHistory = new ArrayList<>(transactionHistory);
@@ -53,9 +56,11 @@ public class TransactionAdapter extends RecyclerView.Adapter<TransactionAdapter.
                 t.getAmount(), t.getSymbol()
         ));
         holder.transactionTextView.setText(t.toString());
-        if (t.getAmount() < 0) {
-            holder.transactionCardView.setCardBackgroundColor(Color.parseColor("#FFF44336"));
-        }
+        holder.transactionCardView.setCardBackgroundColor(
+                t.getAmount() < 0 ?
+                        RED_COLOR:
+                        GREEN_COLOR
+        );
     }
 
     @Override


### PR DESCRIPTION
This fixes a bug in the Transaction History fragment where transaction cards all became red if there were a lot of negative transactions in a row.
I also took the time to refactor the tests and write some more of them (including 2 regression tests for this bug)